### PR TITLE
Apply ecl fix from https://mailman.common-lisp.net/pipermail/ltk-user…

### DIFF
--- a/ltk/ltk.lisp
+++ b/ltk/ltk.lisp
@@ -495,7 +495,7 @@ toplevel             x
 		 proc
 		 )
     #+:ecl(ext:run-program program args :input :stream :output :stream
-:error :output)
+:error :output :wait wt)
     #+:openmcl (let ((proc (ccl:run-program program args :input
 					    :stream :output :stream :wait wt)))
 		 (unless proc


### PR DESCRIPTION
From https://mailman.common-lisp.net/pipermail/ltk-user/attachments/20091110/a9583e05/attachment.patch

It doesn't display the simple hello-world button example without this patch.