### PR TITLE
Fix bug in notebook-enable-traversal

### DIFF
--- a/ltk/ltk.lisp
+++ b/ltk/ltk.lisp
@@ -2415,7 +2415,7 @@ a list of numbers may be given"
 
 (defgeneric notebook-enable-traversal (nb))
 (defmethod notebook-enable-traversal ((nb notebook))
-  (format-wish "ttk::notebook::enableTraversal ~a" nb))
+  (format-wish "ttk::notebook::enableTraversal ~a" (widget-path nb)))
 
 ;; notebook-state
 ;; notebook-tabs


### PR DESCRIPTION
This is a minor bug fix. This allows the following code to work:
```
(with-ltk ()
  (let* ((nb (make-instance 'notebook))
	 (frame1 (make-instance 'frame))
	 (frame2 (make-instance 'frame))
	 (label1 (make-instance 'label :master frame1 :text "Hello World!"))
	 (label2 (make-instance 'label :master frame2 :text "This is the 2nd page")))
    (notebook-enable-traversal nb) ; this failed
    (pack nb)
    (notebook-add nb frame1 :text "Tab 1")
    (notebook-add nb frame2 :text "Tab 2")
    (pack label1 :padx 20 :pady 20)
    (pack label2 :padx 20 :pady 20)
    (notebook-select nb frame1)))
```
Sincerely, Mark.