### PR TITLE
Fixed on-focus and added method for *tk*

### DIFF
--- a/ltk/ltk.lisp
+++ b/ltk/ltk.lisp
@@ -3833,8 +3833,14 @@ set y [winfo y ~a]
 (defmethod on-focus ((tl toplevel) fun)
   (let ((name (create-name)))
     (add-callback name fun)
-    (format-wish "wm protocol WM_TAKE_FOCUS {callback ~A}"
-	      name))
+    (format-wish "wm protocol ~A WM_TAKE_FOCUS {callback ~A}"
+	         (widget-path tl) name))
+  tl)
+(defmethod on-focus ((tl (eql *tk*)) fun)
+  (let ((name (create-name)))
+    (add-callback name fun)
+    (format-wish "wm protocol . WM_TAKE_FOCUS {callback ~A}"
+	         name))
   tl)
 
 (defun iconwindow (tl wid)


### PR DESCRIPTION
The `on-focus` function was missing the widget argument and additionally since `*tk*` is not a `toplevel` widget, it needed a special `eql` method so I added the fix and the `*tk*`-specific method.