### PR TITLE
Avoid errors during validation of entry widget

### DIFF
--- a/ltk/ltk.lisp
+++ b/ltk/ltk.lisp
@@ -1492,7 +1492,7 @@ can be passed to AFTER-CANCEL"
       (validate validate "~@[ -validate ~(~a~)~]" validate "")
       ;(validatecommand validatecommand "~@[ -validatecommand ~(~a~)~]" validatecommand "")
 
-      (validatecommand validatecommand "~@[ -validatecommand {callback ~a;1}~]"
+      (validatecommand validatecommand "~@[ -validatecommand {callback ~a;expr 1}~]"
        (and validatecommand 
         (progn
           (add-callback (name widget) validatecommand)


### PR DESCRIPTION
```lisp
(with-ltk ()
  (let ((input (make-instance 'entry
                              :validate :key ; none, focus, focusin, focusout, key, all
                              :validatecommand (lambda ()
                                                 (print "foo")))))
    (pack (list input))))
```

This will result in the following error.

```
invalid command name "1"
invalid command name "1"
    while executing
"1"
	(in -validatecommand validation command executed by .wc)
    invoked from within
"$w insert insert $s"
    (procedure "ttk::entry::Insert" line 4)
    invoked from within
"ttk::entry::Insert .wc a "
    (command bound to event)
```
